### PR TITLE
Improvements to `ChemicalRecord`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2022-01-10
+### Changed
+- Changed `ChemicalRecord` to an enum that can hold either the full structural information of a molecule or only segment and bond counts and added an `Identifier`. [#19](https://github.com/feos-org/feos-core/pull/19)
+- Removed the `chemical_record` field from `PureRecord` and made `model_record` non-optional. [#19](https://github.com/feos-org/feos-core/pull/19)
+
 ## [0.1.1] - 2021-12-22
 ### Added
 - Added `from_multiple_json` function to `Parameter` trait that is able to read parameters from separate JSON files. [#15](https://github.com/feos-org/feos-core/pull/15)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ argmin = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 indexmap = "1.7"
+either = "1.6"
 numpy = { version = "0.15", optional = true }
 pyo3 = { version = "0.15", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feos-core"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Gernot Bauer <bauer@itt.uni-stuttgart.de>",
            "Philipp Rehner <prehner@ethz.ch"]
 edition = "2018"

--- a/build_wheel/Cargo.toml
+++ b/build_wheel/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "feos_core"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Gernot Bauer <bauer@itt.uni-stuttgart.de>",
-           "Philipp Rehner <rehner@itt.uni-stuttgart.de"]
+           "Philipp Rehner <prehner@ethz.ch"]
 edition = "2018"
 
 [lib]

--- a/src/cubic.rs
+++ b/src/cubic.rs
@@ -16,7 +16,6 @@ use ndarray::{Array1, Array2};
 use num_dual::DualNum;
 use quantity::si::{SIArray1, SIUnit};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::f64::consts::SQRT_2;
 use std::rc::Rc;
 
@@ -102,7 +101,7 @@ impl PengRobinsonParameters {
                     acentric_factor: acentric_factor[i],
                 };
                 let id = Identifier::new("1", None, None, None, None, None);
-                PureRecord::new(id, molarweight[i], None, Some(record), None)
+                PureRecord::new(id, molarweight[i], Some(record), None)
             })
             .collect();
         Ok(PengRobinsonParameters::from_records(
@@ -130,9 +129,7 @@ impl Parameter for PengRobinsonParameters {
         let mut molarweight = Array1::zeros(n);
         let mut kappa = Array1::zeros(n);
 
-        let mut component_index = HashMap::with_capacity(n);
         for (i, record) in pure_records.iter().enumerate() {
-            component_index.insert(record.identifier.clone(), i);
             molarweight[i] = record.molarweight;
             match &record.model_record {
                 Some(r) => {

--- a/src/joback.rs
+++ b/src/joback.rs
@@ -213,6 +213,7 @@ mod tests {
         let segment_records: Vec<SegmentRecord<ModelRecord, JobackRecord>> =
             serde_json::from_str(segments_json).expect("Unable to parse json.");
         let segments = ChemicalRecord::new(
+            Identifier::new("", None, None, None, None, None),
             vec![
                 String::from("-Cl"),
                 String::from("-Cl"),

--- a/src/parameter/chemical_record.rs
+++ b/src/parameter/chemical_record.rs
@@ -1,26 +1,58 @@
+use super::identifier::Identifier;
 use super::segment::SegmentRecord;
 use super::ParameterError;
+use either::Either;
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 
 // Auxiliary structure used to deserialize chemical records without bond information.
 #[derive(Deserialize)]
-struct ChemicalRecordJSON {
-    pub segments: Vec<String>,
-    pub bonds: Option<Vec<[usize; 2]>>,
+#[serde(untagged)]
+enum ChemicalRecordJSON {
+    List {
+        identifier: Identifier,
+        segments: Vec<String>,
+        bonds: Option<Vec<[usize; 2]>>,
+    },
+    Count {
+        identifier: Identifier,
+        segments: HashMap<String, f64>,
+        bonds: Option<HashMap<[String; 2], f64>>,
+    },
 }
 
 /// Chemical information of a substance.
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(from = "ChemicalRecordJSON")]
-pub struct ChemicalRecord {
-    pub segments: Vec<String>,
-    pub bonds: Vec<[usize; 2]>,
+#[serde(untagged)]
+pub enum ChemicalRecord {
+    List {
+        identifier: Identifier,
+        segments: Vec<String>,
+        bonds: Vec<[usize; 2]>,
+    },
+    Count {
+        identifier: Identifier,
+        segments: HashMap<String, f64>,
+        bonds: HashMap<[String; 2], f64>,
+    },
 }
 
 impl From<ChemicalRecordJSON> for ChemicalRecord {
     fn from(record: ChemicalRecordJSON) -> Self {
-        Self::new(record.segments, record.bonds)
+        match record {
+            ChemicalRecordJSON::List {
+                identifier,
+                segments,
+                bonds,
+            } => Self::new(identifier, segments, bonds),
+            ChemicalRecordJSON::Count {
+                identifier,
+                segments,
+                bonds,
+            } => Self::new_count(identifier, segments, bonds),
+        }
     }
 }
 
@@ -28,14 +60,66 @@ impl ChemicalRecord {
     /// Create a new `ChemicalRecord`.
     ///
     /// If no bonds are given, the molecule is assumed to be linear.
-    pub fn new(segments: Vec<String>, bonds: Option<Vec<[usize; 2]>>) -> ChemicalRecord {
+    pub fn new(
+        identifier: Identifier,
+        segments: Vec<String>,
+        bonds: Option<Vec<[usize; 2]>>,
+    ) -> ChemicalRecord {
         let bonds = bonds.unwrap_or_else(|| {
             (0..segments.len() - 1)
                 .zip(1..segments.len())
                 .map(|x| [x.0, x.1])
                 .collect()
         });
-        Self { segments, bonds }
+        Self::List {
+            identifier,
+            segments,
+            bonds,
+        }
+    }
+
+    /// Create a new `ChemicalRecord` from a segment count.
+    pub fn new_count(
+        identifier: Identifier,
+        segments: HashMap<String, f64>,
+        bonds: Option<HashMap<[String; 2], f64>>,
+    ) -> ChemicalRecord {
+        let bonds = bonds.unwrap_or_default();
+        Self::Count {
+            identifier,
+            segments,
+            bonds,
+        }
+    }
+
+    pub fn segments(&self) -> Either<&Vec<String>, &HashMap<String, f64>> {
+        match self {
+            Self::List {
+                identifier: _,
+                segments,
+                bonds: _,
+            } => Either::Left(segments),
+            Self::Count {
+                identifier: _,
+                segments,
+                bonds: _,
+            } => Either::Right(segments),
+        }
+    }
+
+    pub fn identifier(&self) -> &Identifier {
+        match self {
+            Self::List {
+                identifier,
+                segments: _,
+                bonds: _,
+            } => identifier,
+            Self::Count {
+                identifier,
+                segments: _,
+                bonds: _,
+            } => identifier,
+        }
     }
 
     /// Count the number of occurences of each individual segment in the
@@ -46,27 +130,98 @@ impl ChemicalRecord {
         &self,
         segment_records: &[SegmentRecord<M, I>],
     ) -> Result<HashMap<SegmentRecord<M, I>, f64>, ParameterError> {
-        let mut counts = HashMap::with_capacity(self.segments.len());
-        let segments = self.segment_map(segment_records)?;
-        for si in &self.segments {
-            let key = segments.get(si).unwrap().clone();
-            let entry = counts.entry(key).or_insert(0.0);
-            *entry += 1.0;
-        }
-        Ok(counts)
+        let segment_map = self.segment_map(segment_records)?;
+        Ok(match self.segments() {
+            Either::Left(segments) => {
+                let mut counts = HashMap::with_capacity(segments.len());
+                for si in segments {
+                    let key = segment_map.get(si).unwrap().clone();
+                    let entry = counts.entry(key).or_insert(0.0);
+                    *entry += 1.0;
+                }
+                counts
+            }
+            Either::Right(segments) => segments
+                .iter()
+                .map(|(id, &c)| (segment_map[id].clone(), c))
+                .collect(),
+        })
     }
 
     /// Count the number of occurences of each individual segment identifier in the
     /// chemical record.
     ///
     /// The map contains the segment identifier as key and the count as (float) value.
-    pub fn segment_id_count(&self) -> HashMap<String, f64> {
-        let mut counts = HashMap::with_capacity(self.segments.len());
-        for si in &self.segments {
-            let entry = counts.entry(si.clone()).or_insert(0.0);
-            *entry += 1.0;
+    pub fn segment_id_count(&self) -> Cow<HashMap<String, f64>> {
+        match self.segments() {
+            Either::Left(segments) => {
+                let mut counts = HashMap::with_capacity(segments.len());
+                for si in segments {
+                    let entry = counts.entry(si.clone()).or_insert(0.0);
+                    *entry += 1.0;
+                }
+                Cow::Owned(counts)
+            }
+            Either::Right(segments) => Cow::Borrowed(segments),
         }
-        counts
+    }
+
+    /// Count the number of occurences of each individual segment identifier and each
+    /// pair of identifiers for every bond in the chemical record.
+    #[allow(clippy::type_complexity)]
+    pub fn segment_and_bond_count(
+        &self,
+    ) -> (Cow<HashMap<String, f64>>, Cow<HashMap<[String; 2], f64>>) {
+        match self {
+            Self::List {
+                identifier: _,
+                segments,
+                bonds,
+            } => {
+                let mut segment_counts = HashMap::with_capacity(segments.len());
+                for si in segments {
+                    let entry = segment_counts.entry(si.clone()).or_insert(0.0);
+                    *entry += 1.0;
+                }
+
+                let mut bond_counts = HashMap::new();
+                for b in bonds {
+                    let s1 = segments[b[0]].clone();
+                    let s2 = segments[b[1]].clone();
+                    let indices = if s1 > s2 { [s2, s1] } else { [s1, s2] };
+                    let entry = bond_counts.entry(indices).or_insert(0.0);
+                    *entry += 1.0;
+                }
+                (Cow::Owned(segment_counts), Cow::Owned(bond_counts))
+            }
+            Self::Count {
+                identifier: _,
+                segments,
+                bonds,
+            } => (Cow::Borrowed(segments), Cow::Borrowed(bonds)),
+        }
+    }
+
+    /// Return the full segment and bond information for the molecule
+    /// if possible.
+    #[allow(clippy::type_complexity)]
+    pub fn segment_and_bond_list(
+        &self,
+    ) -> Result<(&Vec<String>, &Vec<[usize; 2]>), ParameterError> {
+        match self {
+            Self::List {
+                identifier: _,
+                segments,
+                bonds,
+            } => Ok((segments, bonds)),
+            Self::Count {
+                identifier: _,
+                segments: _,
+                bonds: _,
+            } => Err(ParameterError::IncompatibleParameters(
+                "No detailed structural information available.".into(),
+            )),
+        }
     }
 
     /// Build a HashMap from SegmentRecords for the segments.
@@ -77,7 +232,10 @@ impl ChemicalRecord {
         &self,
         segment_records: &[SegmentRecord<M, I>],
     ) -> Result<HashMap<String, SegmentRecord<M, I>>, ParameterError> {
-        let queried: HashSet<String> = self.segments.iter().cloned().collect();
+        let queried: HashSet<_> = match self.segments() {
+            Either::Left(segments) => segments.iter().cloned().collect(),
+            Either::Right(segments) => segments.keys().cloned().collect(),
+        };
         let mut segments: HashMap<String, SegmentRecord<M, I>> = segment_records
             .iter()
             .map(|r| (r.identifier.clone(), r.clone()))
@@ -89,7 +247,7 @@ impl ChemicalRecord {
             return Err(ParameterError::ComponentsNotFound(msg));
         };
         Ok(queried
-            .intersection(&available)
+            .iter()
             .map(|s| segments.remove_entry(s).unwrap())
             .collect())
     }
@@ -97,7 +255,27 @@ impl ChemicalRecord {
 
 impl std::fmt::Display for ChemicalRecord {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "ChemicalRecord(segments={:?}", self.segments)?;
-        write!(f, ", bonds={:?})", self.bonds)
+        match self {
+            Self::List {
+                identifier,
+                segments,
+                bonds,
+            } => {
+                write!(f, "ChemicalRecord(")?;
+                write!(f, "\n\tidentifier={},", identifier)?;
+                write!(f, "\n\tsegments={:?},", segments)?;
+                write!(f, "\n\tbonds={:?}\n)", bonds)
+            }
+            Self::Count {
+                identifier,
+                segments,
+                bonds,
+            } => {
+                write!(f, "ChemicalRecord(")?;
+                write!(f, "\n\tidentifier={},", identifier)?;
+                write!(f, "\n\tsegments={:?},", segments)?;
+                write!(f, "\n\tbonds={:?}\n)", bonds)
+            }
+        }
     }
 }

--- a/src/parameter/model_record.rs
+++ b/src/parameter/model_record.rs
@@ -7,9 +7,7 @@ use serde::{Deserialize, Serialize};
 pub struct PureRecord<M, I> {
     pub identifier: Identifier,
     pub molarweight: f64,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub model_record: Option<M>,
+    pub model_record: M,
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ideal_gas_record: Option<I>,
@@ -20,7 +18,7 @@ impl<M, I> PureRecord<M, I> {
     pub fn new(
         identifier: Identifier,
         molarweight: f64,
-        model_record: Option<M>,
+        model_record: M,
         ideal_gas_record: Option<I>,
     ) -> Self {
         Self {
@@ -49,7 +47,7 @@ impl<M, I> PureRecord<M, I> {
             model_segments.push((s.model_record, n));
             ideal_gas_segments.push(s.ideal_gas_record.map(|ig| (ig, n)));
         }
-        let model_record = Some(M::from_segments(&model_segments));
+        let model_record = M::from_segments(&model_segments);
 
         let ideal_gas_segments: Option<Vec<_>> = ideal_gas_segments.into_iter().collect();
         let ideal_gas_record = ideal_gas_segments.as_deref().map(I::from_segments);
@@ -67,9 +65,7 @@ where
         write!(f, "PureRecord(")?;
         write!(f, "\n\tidentifier={},", self.identifier)?;
         write!(f, "\n\tmolarweight={},", self.molarweight)?;
-        if let Some(m) = self.model_record.as_ref() {
-            write!(f, "\n\tmodel_record={},", m)?;
-        }
+        write!(f, "\n\tmodel_record={},", self.model_record)?;
         if let Some(i) = self.ideal_gas_record.as_ref() {
             write!(f, "\n\tideal_gas_record={},", i)?;
         }

--- a/src/python/parameter.rs
+++ b/src/python/parameter.rs
@@ -359,7 +359,7 @@ macro_rules! impl_pure_record {
         ///     The identifier of the pure component.
         /// molarweight : float
         ///     The molar weight (in g/mol) of the pure component.
-        /// model_record : ModelRecord, optional
+        /// model_record : ModelRecord
         ///     The pure component model parameters.
         /// ideal_gas_record: IdealGasRecord, optional
         ///     The pure component parameters for the ideal gas model.
@@ -368,9 +368,7 @@ macro_rules! impl_pure_record {
         /// -------
         /// PureRecord
         #[pyclass(name = "PureRecord")]
-        #[pyo3(
-            text_signature = "(identifier, molarweight, model_record=None, ideal_gas_record=None)"
-        )]
+        #[pyo3(text_signature = "(identifier, molarweight, model_record, ideal_gas_record=None)")]
         #[derive(Clone)]
         pub struct PyPureRecord(pub PureRecord<$model_record, $ideal_gas_record>);
 
@@ -380,13 +378,13 @@ macro_rules! impl_pure_record {
             fn new(
                 identifier: PyIdentifier,
                 molarweight: f64,
-                model_record: Option<$py_model_record>,
+                model_record: $py_model_record,
                 ideal_gas_record: Option<$py_ideal_gas_record>,
             ) -> PyResult<Self> {
                 Ok(Self(PureRecord::new(
                     identifier.0,
                     molarweight,
-                    model_record.map(|mr| mr.0),
+                    model_record.0,
                     ideal_gas_record.map(|ig| ig.0),
                 )))
             }
@@ -412,13 +410,13 @@ macro_rules! impl_pure_record {
             }
 
             #[getter]
-            fn get_model_record(&self) -> Option<$py_model_record> {
-                self.0.model_record.clone().map($py_model_record)
+            fn get_model_record(&self) -> $py_model_record {
+                $py_model_record(self.0.model_record.clone())
             }
 
             #[setter]
             fn set_model_record(&mut self, model_record: $py_model_record) {
-                self.0.model_record = Some(model_record.0);
+                self.0.model_record = model_record.0;
             }
 
             #[getter]

--- a/src/python/parameter.rs
+++ b/src/python/parameter.rs
@@ -1,7 +1,9 @@
 use crate::impl_json_handling;
-use crate::parameter::{BinaryRecord, ChemicalRecord, Identifier, NoRecord, ParameterError};
-use pyo3::exceptions::PyRuntimeError;
+use crate::parameter::{BinaryRecord, ChemicalRecord, Identifier, ParameterError};
+use either::Either;
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
+use std::collections::HashMap;
 
 impl From<ParameterError> for PyErr {
     fn from(e: ParameterError) -> PyErr {
@@ -124,6 +126,8 @@ impl_json_handling!(PyIdentifier);
 ///
 /// Parameters
 /// ----------
+/// identifier : Identifier
+///     The identifier of the pure component.
 /// segments : [str]
 ///     List of segments, that the molecule consists of.
 /// bonds : [[int, int]], optional
@@ -137,34 +141,69 @@ impl_json_handling!(PyIdentifier);
 /// ChemicalRecord
 #[pyclass(name = "ChemicalRecord")]
 #[derive(Clone)]
-#[pyo3(text_signature = "(segments, bonds=None)")]
+#[pyo3(text_signature = "(identifier, segments, bonds=None)")]
 pub struct PyChemicalRecord(pub ChemicalRecord);
 
 #[pymethods]
 impl PyChemicalRecord {
     #[new]
-    fn new(segments: Vec<String>, bonds: Option<Vec<[usize; 2]>>) -> Self {
-        Self(ChemicalRecord::new(segments, bonds))
+    fn new(identifier: PyIdentifier, segments: &PyAny, bonds: Option<&PyAny>) -> PyResult<Self> {
+        if let Ok(segments) = segments.extract::<Vec<String>>() {
+            let bonds = bonds
+                .map(|bonds| bonds.extract::<Vec<[usize; 2]>>())
+                .transpose()?;
+            Ok(Self(ChemicalRecord::new(identifier.0, segments, bonds)))
+        } else if let Ok(segments) = segments.extract::<HashMap<String, f64>>() {
+            let bonds = bonds
+                .map(|bonds| bonds.extract::<HashMap<[String; 2], f64>>())
+                .transpose()?;
+            Ok(Self(ChemicalRecord::new_count(
+                identifier.0,
+                segments,
+                bonds,
+            )))
+        } else {
+            Err(PyValueError::new_err(
+                "`segments` must either be a list or a dict of strings.",
+            ))
+        }
     }
 
     #[getter]
-    fn get_segments(&self) -> Vec<String> {
-        self.0.segments.clone()
-    }
-
-    #[setter]
-    fn set_segments(&mut self, segments: Vec<String>) {
-        self.0.segments = segments
+    fn get_identifier(&self) -> PyIdentifier {
+        PyIdentifier(self.0.identifier().clone())
     }
 
     #[getter]
-    fn get_bonds(&self) -> Vec<[usize; 2]> {
-        self.0.bonds.clone()
+    fn get_segments(&self, py: Python) -> PyObject {
+        match &self.0.segments() {
+            Either::Left(segments) => segments.to_object(py),
+            Either::Right(segments) => segments.to_object(py),
+        }
     }
 
-    #[setter]
-    fn set_bonds(&mut self, bonds: Vec<[usize; 2]>) {
-        self.0.bonds = bonds
+    #[getter]
+    fn get_bonds(&self, py: Python) -> PyObject {
+        match &self.0 {
+            ChemicalRecord::List {
+                identifier: _,
+                segments: _,
+                bonds,
+            } => bonds
+                .iter()
+                .map(|[a, b]| (a, b))
+                .collect::<Vec<_>>()
+                .to_object(py),
+            ChemicalRecord::Count {
+                identifier: _,
+                segments: _,
+                bonds,
+            } => bonds
+                .iter()
+                .map(|([a, b], c)| ((a, b), c))
+                .collect::<HashMap<_, _>>()
+                .to_object(py),
+        }
     }
 }
 
@@ -309,10 +348,6 @@ impl pyo3::class::basic::PyObjectProtocol for PyBinarySegmentRecord {
 
 impl_json_handling!(PyBinarySegmentRecord);
 
-#[pyclass(name = "NoRecord")]
-#[derive(Clone)]
-pub struct PyNoRecord(pub NoRecord);
-
 #[macro_export]
 macro_rules! impl_pure_record {
     ($model_record:ident, $py_model_record:ident, $ideal_gas_record:ident, $py_ideal_gas_record:ident) => {
@@ -328,16 +363,16 @@ macro_rules! impl_pure_record {
         ///     The pure component model parameters.
         /// ideal_gas_record: IdealGasRecord, optional
         ///     The pure component parameters for the ideal gas model.
-        /// chemical_record: ChemicalRecord, optional
-        ///     The chemical record of the pure component.
         ///
         /// Returns
         /// -------
         /// PureRecord
         #[pyclass(name = "PureRecord")]
-        #[pyo3(text_signature = "(identifier, molarweight, model_record=None, ideal_gas_record=None, chemical_record=None)")]
+        #[pyo3(
+            text_signature = "(identifier, molarweight, model_record=None, ideal_gas_record=None)"
+        )]
         #[derive(Clone)]
-        pub struct PyPureRecord(PureRecord<$model_record, $ideal_gas_record>);
+        pub struct PyPureRecord(pub PureRecord<$model_record, $ideal_gas_record>);
 
         #[pymethods]
         impl PyPureRecord {
@@ -347,12 +382,10 @@ macro_rules! impl_pure_record {
                 molarweight: f64,
                 model_record: Option<$py_model_record>,
                 ideal_gas_record: Option<$py_ideal_gas_record>,
-                chemical_record: Option<PyChemicalRecord>,
             ) -> PyResult<Self> {
                 Ok(Self(PureRecord::new(
                     identifier.0,
                     molarweight,
-                    chemical_record.map(|cr| cr.0),
                     model_record.map(|mr| mr.0),
                     ideal_gas_record.map(|ig| ig.0),
                 )))
@@ -396,16 +429,6 @@ macro_rules! impl_pure_record {
             #[setter]
             fn set_ideal_gas_record(&mut self, ideal_gas_record: $py_ideal_gas_record) {
                 self.0.ideal_gas_record = Some(ideal_gas_record.0);
-            }
-
-            #[getter]
-            fn get_chemical_record(&self) -> Option<PyChemicalRecord> {
-                self.0.chemical_record.clone().map(PyChemicalRecord)
-            }
-
-            #[setter]
-            fn set_chemical_record(&mut self, chemical_record: PyChemicalRecord) {
-                self.0.chemical_record = Some(chemical_record.0);
             }
         }
 
@@ -645,7 +668,7 @@ macro_rules! impl_parameter_from_segments {
             ///
             /// Parameters
             /// ----------
-            /// pure_records : [PureRecord]
+            /// chemical_records : [ChemicalRecord]
             ///     A list of pure component parameters.
             /// segment_records : [SegmentRecord]
             ///     A list of records containing the parameters of
@@ -653,14 +676,14 @@ macro_rules! impl_parameter_from_segments {
             /// binary_segment_records : [BinarySegmentRecord], optional
             ///     A list of binary segment-segment parameters.
             #[staticmethod]
-            #[pyo3(text_signature = "(pure_records, segment_records, binary_segment_records=None)")]
+            #[pyo3(text_signature = "(chemical_records, segment_records, binary_segment_records=None)")]
             fn from_segments(
-                pure_records: Vec<PyPureRecord>,
+                chemical_records: Vec<PyChemicalRecord>,
                 segment_records: Vec<PySegmentRecord>,
                 binary_segment_records: Option<Vec<PyBinarySegmentRecord>>,
             ) -> Result<Self, ParameterError> {
                 Ok(Self(Rc::new(<$parameter>::from_segments(
-                    pure_records.into_iter().map(|pr| pr.0).collect(),
+                    chemical_records.into_iter().map(|cr| cr.0).collect(),
                     segment_records.into_iter().map(|sr| sr.0).collect(),
                     binary_segment_records.map(|r| r.into_iter().map(|r| BinaryRecord{id1:r.0.id1,id2:r.0.id2,model_record:r.0.model_record.into()}).collect()),
                 )?)))


### PR DESCRIPTION
This PR improves the flexibility of the `ChemicalRecord` struct. To make it more seamlessly applicable to CAMD problems, in which the numbers of segments and bonds are non-integer, `ChemicalRecord` is changed to an enum that can either store the full connectivity information or only the number of segments and bonds.

Further, the `chemical_record` field is removed from `PureRecord` and `ChemicalRecord` obtained its own `identifier` field. Note that model parameters and segment information can still be stored in the same JSON file as serde will simply ignore additional entries. With this change, `ChemicalRecord` can be used between different crates as the single data structure required to specify molecules in group contribution methods (together with model-specific segment parameters).