### PR TITLE
Fix state constructor for obscure specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Fix state constructor for $T$, $p$, $V$, $x_i$ specification. [#26](https://github.com/feos-org/feos-core/pull/26)
+- Fix state constructor for `T`, `p`, `V`, `x_i` specification. [#26](https://github.com/feos-org/feos-core/pull/26)
 
 ## [0.1.3] - 2022-01-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix state constructor for $T$, $p$, $V$, $x_i$ specification. [#26](https://github.com/feos-org/feos-core/pull/26)
 
 ## [0.1.3] - 2022-01-21
 ### Added

--- a/src/cubic.rs
+++ b/src/cubic.rs
@@ -72,7 +72,7 @@ impl std::fmt::Display for PengRobinsonParameters {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.pure_records
             .iter()
-            .try_for_each(|pr| writeln!(f, "{}", pr.to_string()))?;
+            .try_for_each(|pr| writeln!(f, "{}", pr))?;
         writeln!(f, "\nk_ij:\n{}", self.k_ij)
     }
 }

--- a/src/python/cubic.rs
+++ b/src/python/cubic.rs
@@ -19,6 +19,14 @@ use std::rc::Rc;
 #[derive(Clone)]
 pub struct PyPengRobinsonRecord(PengRobinsonRecord);
 
+#[pymethods]
+impl PyPengRobinsonRecord {
+    #[new]
+    fn new(tc: f64, pc: f64, acentric_factor: f64) -> Self {
+        Self(PengRobinsonRecord::new(tc, pc, acentric_factor))
+    }
+}
+
 #[pyproto]
 impl pyo3::class::basic::PyObjectProtocol for PyPengRobinsonRecord {
     fn __repr__(&self) -> PyResult<String> {

--- a/src/utils/estimator.rs
+++ b/src/utils/estimator.rs
@@ -115,7 +115,7 @@ where
 impl<U: EosUnit, E: EquationOfState> fmt::Display for Estimator<U, E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for d in self.data.iter() {
-            writeln!(f, "{}", d.to_string())?;
+            writeln!(f, "{}", d)?;
         }
         Ok(())
     }


### PR DESCRIPTION
In this example, the moles of the state are now correctly obtained in a density iteration instead of default values.

```python
T = 25*CELSIUS
V = (100*ANGSTROM)**3
p = BAR
z = 3e-4
State(func, T, pressure=p, molefracs=np.array([1-z,z]), volume=V).pressure()
>>> 100 kPa
```

closes #25 

To facilitate testing, this PR also adds a Python constructor for `PengRobinsonRecord`.